### PR TITLE
Fixing default null property handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ PM> Install-Package MangaDexSharp
 
 ## Setup
 You can either use it directly or via dependency injection (for use with asp.net core).
-You will need to ensure that you register the `CardboardBox.Http` and `CardboardBox.Json` packages as well (see the example below).
+> **_NOTE:_** It is no longer necessary to manually register the `CardboardBox.Http` and `CardboardBox.Json` packages as of v1.0.20.
 
 ### Depdency Injection:
 ```csharp
@@ -27,15 +27,9 @@ var builder = WebApplication.CreateBuilder(args);
 ...
 
 //This will find the authentication token in your configuration file (appsettings.json) under: "MangaDex:Token"
-builder.Services
-    .AddMangaDex()
-    .AddJson()
-    .AddCardboardHttp(); 
+builder.Services.AddMangaDex(); 
 //Or, if you want to inject the token directly you can use this (You don't need both of these.):
-builder.Services
-    .AddMangaDex("<AUTH TOKEN HERE>")
-    .AddJson()
-    .AddCardboardHttp();
+builder.Services.AddMangaDex("<AUTH TOKEN HERE>");
 
 var app = builder.Build();
 ```

--- a/src/MangaDexSharp/Extensions.cs
+++ b/src/MangaDexSharp/Extensions.cs
@@ -110,8 +110,11 @@ public static class Extensions
 	private static IServiceCollection AddBaseMangaDex(this IServiceCollection services)
 	{
 		return services
+			.AddHttpClient()
 			.AddTransient<IMangaDex, MangaDex>()
 			.AddTransient<IMdApiService, MdApiService>()
+			.AddTransient<IMdJsonService, MdJsonService>()
+			.AddTransient<IMdCacheService, MdCacheService>()
 
 			.AddTransient<IMangaDexMangaService, MangaDexMangaService>()
 			.AddTransient<IMangaDexChapterService, MangaDexChapterService>()

--- a/src/MangaDexSharp/Helpers/MdApiService.cs
+++ b/src/MangaDexSharp/Helpers/MdApiService.cs
@@ -35,9 +35,9 @@ public class MdApiService : ApiService, IMdApiService
     /// <param name="logger"></param>
     /// <param name="creds"></param>
     public MdApiService(
-        IHttpClientFactory httpFactory, 
-        IJsonService json, 
-        ICacheService cache, 
+        IHttpClientFactory httpFactory,
+        IMdJsonService json,
+        IMdCacheService cache, 
         ILogger<ApiService> logger,
         ICredentialsService creds) : base(httpFactory, json, cache, logger)
     {

--- a/src/MangaDexSharp/Helpers/MdCacheService.cs
+++ b/src/MangaDexSharp/Helpers/MdCacheService.cs
@@ -1,0 +1,11 @@
+﻿namespace MangaDexSharp;
+
+/// <summary>
+/// Exposes the underlying caching mechanism for Cardboard HTTP tailed to MangaDex
+/// </summary>
+public interface IMdCacheService : ICacheService { }
+
+internal class MdCacheService : DiskCacheService, IMdCacheService
+{
+    public MdCacheService(IMdJsonService json) : base(json) { }
+}

--- a/src/MangaDexSharp/Helpers/MdJsonService.cs
+++ b/src/MangaDexSharp/Helpers/MdJsonService.cs
@@ -1,0 +1,27 @@
+﻿using CardboardBox.Json;
+
+namespace MangaDexSharp;
+
+/// <summary>
+/// Exposes common Json serialization and deserialization methods tailored to MangaDex
+/// </summary>
+public interface IMdJsonService : IJsonService { }
+
+/// <summary>
+/// The concrete implementation for the <see cref="IMdJsonService"/>
+/// </summary>
+public class MdJsonService : SystemTextJsonService, IMdJsonService
+{
+    /// <summary>
+    /// The default JSON Serialization options for the MangaDex API
+    /// </summary>
+    public static JsonSerializerOptions? DEFAULT_OPTIONS = null;
+
+    /// <summary>
+    /// The concrete implementation for the <see cref="IMdJsonService"/>
+    /// </summary>
+    public MdJsonService() : base(DEFAULT_OPTIONS ??= new JsonSerializerOptions
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    }) { }
+}

--- a/src/MangaDexSharp/MangaDex.cs
+++ b/src/MangaDexSharp/MangaDex.cs
@@ -241,9 +241,7 @@ public class MangaDex : IMangaDex
     public static IMangaDex Create(string? token = null, string? apiUrl = null, Action<IServiceCollection>? config = null, string? userAgent = null, bool throwOnError = false)
 	{
 		var create = new ServiceCollection()
-			.AddMangaDex(token ?? string.Empty, apiUrl, userAgent, throwOnError)
-			.AddCardboardHttp()
-			.AddJson();
+			.AddMangaDex(token ?? string.Empty, apiUrl, userAgent, throwOnError);
 
 		config?.Invoke(create);
 

--- a/src/MangaDexSharp/MangaDexSharp.csproj
+++ b/src/MangaDexSharp/MangaDexSharp.csproj
@@ -13,7 +13,7 @@
     <RepositoryUrl>https://github.com/calico-crusade/mangadex-sharp</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Manga;Mangadex;Anime;Cardboard;mangadex-sharp;</PackageTags>
-    <Version>1.0.19</Version>
+    <Version>1.0.20</Version>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <PackageReadmeFile>README.md</PackageReadmeFile>


### PR DESCRIPTION
This should fix #5 .

By default, null properties will be excluded from serialized objects that are posted. I had a discussion with the other MD staff and it's best to assume that all null properties should be excluded instead of explicitly written as null. If any fields are found to be in conflict with this, they can be overridden or we can reassess the default handling policy later.

This change also removes the need to manually register `CardboardBox.Http` and `CardboardBox.Json` packages. 
These now have their own overridden variants within the code: [MdJsonService](src/MangaDexSharp/Helpers/MdJsonService.cs) and [MdCacheService](src/MangaDexSharp/Helpers/MdCacheService.cs)
This simplifies setup procedure for using the library with DI. 
