### PR TITLE
Fix multiple files upload

### DIFF
--- a/src/MangaDexSharp/MangaDexUploadService.cs
+++ b/src/MangaDexSharp/MangaDexUploadService.cs
@@ -139,7 +139,7 @@ internal class MangaDexUploadService : IMangaDexUploadService
 			fileContent.Headers.ContentType = new MediaTypeHeaderValue(CONTENT_TYPE_FILE);
 			fileContent.Headers.ContentDisposition = new ContentDispositionHeaderValue("form-data")
 			{
-				Name = "file",
+				Name = "file" + (i + 1),
 				FileName = file.FileName
 			};
             body.Add(fileContent, "file" + (i + 1), file.FileName);


### PR DESCRIPTION
Fixes upload with multiple files. 

It occurs because all files have the same name inside form-data

Repro code: 

```csharp

using MangaDexSharp;

var dexUser = "";
var dexPass = "";
var clientId = "";
var clientSecret = "";

var dex = MangaDex.Create();
var token = await dex.Auth.Personal(clientId, clientSecret, dexUser, dexPass);

var existingSession = await dex.Upload.Get(token.AccessToken);
if (existingSession.ErrorOccurred is false)
    await dex.Upload.Abandon(existingSession.Data.Id, token.AccessToken);

var mangaId = "f9c33607-9180-4ba6-b85c-e4b5faee7192"; // Official "Test" Manga
var groupId = ""; //  Any group you have upload access
var session = await dex.Upload.Begin(mangaId, [groupId], token.AccessToken);

// some pages paths
var file1Path = Path.Combine(Directory.GetCurrentDirectory(), "1.png");
var file2Path = Path.Combine(Directory.GetCurrentDirectory(), "2.png");

using var file1Stream = File.OpenRead(file1Path);
using var file2Stream = File.OpenRead(file2Path);

StreamFileUpload[] filesToUpload =
[
    new(Path.GetFileName(file1Path), file1Stream),
    new(Path.GetFileName(file2Path), file2Stream),
];

var uploadResult = await dex.Upload.Upload(session.Data.Id, token.AccessToken, files: filesToUpload);

Console.WriteLine(uploadResult.Data.Count); // returns 1, not 2

```

Thanks for your library!